### PR TITLE
Make BUILD_REQUEST_MARKER configurable

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -84,9 +84,6 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
 
     public String getTriggerPhrase() {
-        if (triggerPhrase.length() < 5) {
-            return "test this please";
-        }
         return triggerPhrase;
     }
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -28,6 +28,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String repositoryOwner;
     private final String repositoryName;
     private final String ciSkipPhrases;
+    private final String triggerPhrase;
     transient private BitbucketPullRequestsBuilder bitbucketPullRequestsBuilder;
 
     @Extension
@@ -41,7 +42,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String password,
             String repositoryOwner,
             String repositoryName,
-            String ciSkipPhrases) throws ANTLRException {
+            String ciSkipPhrases,
+            String triggerPhrase) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
         this.cron = cron;
@@ -50,6 +52,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.ciSkipPhrases = ciSkipPhrases;
+        this.triggerPhrase = triggerPhrase;
     }
 
     public String getProjectPath() {
@@ -78,6 +81,13 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public String getCiSkipPhrases() {
         return ciSkipPhrases;
+    }
+
+    public String getTriggerPhrase() {
+        if (triggerPhrase.length() < 5) {
+            return "test this please";
+        }
+        return triggerPhrase;
     }
 
     @Override

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -19,10 +19,11 @@ public class BitbucketRepository {
     public static final String BUILD_START_MARKER = "[*BuildStarted*] %s";
     public static final String BUILD_FINISH_MARKER = "[*BuildFinished*] %s";
     public static final String BUILD_FINISH_SENTENCE = BUILD_FINISH_MARKER + " \n\n **%s** - %s";
-    public static final String BUILD_REQUEST_MARKER = "test this please";
 
     public static final String BUILD_SUCCESS_COMMENT =  ":star:SUCCESS";
     public static final String BUILD_FAILURE_COMMENT = ":x:FAILURE";
+    public String BUILD_REQUEST_MARKER = " ";
+
     private String projectPath;
     private BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;
@@ -40,6 +41,7 @@ public class BitbucketRepository {
                 trigger.getPassword(),
                 trigger.getRepositoryOwner(),
                 trigger.getRepositoryName());
+        BUILD_REQUEST_MARKER = this.trigger.getTriggerPhrase();
     }
 
     public Collection<BitbucketPullRequestResponseValue> getTargetPullRequests() {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -22,7 +22,7 @@ public class BitbucketRepository {
 
     public static final String BUILD_SUCCESS_COMMENT =  ":star:SUCCESS";
     public static final String BUILD_FAILURE_COMMENT = ":x:FAILURE";
-    public String BUILD_REQUEST_MARKER = " ";
+    public String BUILD_REQUEST_MARKER = "test this please";
 
     private String projectPath;
     private BitbucketPullRequestsBuilder builder;

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -17,4 +17,7 @@
   <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
     <f:textbox />
   </f:entry>
+  <f:entry title="Comment phrase to re-trigger build" field="triggerPhrase">
+    <f:textbox />
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Quick change to add an input field to the plugin configuration to set the comment phrase the plugin looks for to trigger a rebuild. My team wasn't too happy with using "test this please" as it was ambiguous as to whom the message was directed.

Note: I really don't know java at all. This built and ran for me, but please read the diff carefully. Thanks!
