### PR TITLE
Add ability to insert comment from file.

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -28,6 +28,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String repositoryOwner;
     private final String repositoryName;
     private final String ciSkipPhrases;
+    private final String commentFilePath;
     private final boolean checkDestinationCommit;
     
     transient private BitbucketPullRequestsBuilder bitbucketPullRequestsBuilder;
@@ -44,6 +45,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String repositoryOwner,
             String repositoryName,
             String ciSkipPhrases,
+            String commentFilePath,
             boolean checkDestinationCommit
             ) throws ANTLRException {
         super(cron);
@@ -54,6 +56,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.ciSkipPhrases = ciSkipPhrases;
+        this.commentFilePath = commentFilePath;
         this.checkDestinationCommit = checkDestinationCommit;
     }
 
@@ -85,6 +88,10 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         return ciSkipPhrases;
     }
     
+    public String getCommentFilePath() {
+        return commentFilePath;
+    }
+
     public boolean getCheckDestinationCommit() {
     	return checkDestinationCommit;
     }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuilds.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuilds.java
@@ -48,15 +48,8 @@ public class BitbucketBuilds {
             return;
         }
         Result result = build.getResult();
-        String rootUrl = Jenkins.getInstance().getRootUrl();
-        String buildUrl = "";
-        if (rootUrl == null) {
-            buildUrl = " PLEASE SET JENKINS ROOT URL FROM GLOBAL CONFIGURATION " + build.getUrl();
-        }
-        else {
-            buildUrl = rootUrl + build.getUrl();
-        }
+
         repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
-        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl);
+        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, build);
     }
 }

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -17,6 +17,9 @@
   <f:entry title="CI Skip Phrases" field="ciSkipPhrases">
     <f:textbox />
   </f:entry>
+  <f:entry title="Comment file path" field="commentFilePath">
+    <f:textbox />
+  </f:entry>
   <f:entry title="Rebuild if destination branch changes?" field="checkDestinationCommit">
     <f:checkbox />
   </f:entry>


### PR DESCRIPTION
Currently BitBucket pull request builder allows add only link to Jenkins job. I've added implementation which allows you specify file as source for new comment.

![image](https://cloud.githubusercontent.com/assets/1316234/5154166/20b13d80-7254-11e4-8d11-8db39a6acfd6.png)

In the Jenkins job you can write any data to file and this will be in comment on BitBucket.

```
phpcs --standard=Zend ./includes/path.inc > ${WORKSPACE}/comment.md
```
