### PR TITLE
Return empty collections instead of null to prevent NPE.

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketApiClient.java
@@ -10,6 +10,7 @@ import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -42,7 +43,7 @@ public class BitbucketApiClient {
         } catch(Exception e) {
             logger.log(Level.WARNING, "invalid pull request response.", e);
         }
-        return null;
+        return Collections.EMPTY_LIST;
     }
 
     public List<BitbucketPullRequestComment> getPullRequestComments(String commentOwnerName, String commentRepositoryName, String pullRequestId) {
@@ -53,7 +54,7 @@ public class BitbucketApiClient {
         } catch(Exception e) {
             logger.log(Level.WARNING, "invalid pull request response.", e);
         }
-        return null;
+        return Collections.EMPTY_LIST;
     }
 
     public void deletePullRequestComment(String pullRequestId, String commentId) {


### PR DESCRIPTION
An attempt to fetch pull requests when none exists results in a NPE.

bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger.run() failed for hudson.model.FreeStyleProject@2d81c270[]
java.lang.NullPointerException
	at bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketRepository.getTargetPullRequests(BitbucketRepository.java:55)
	at bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketPullRequestsBuilder.run(BitbucketPullRequestsBuilder.java:30)
	at bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger.run(BitbucketBuildTrigger.java:145)
	at hudson.triggers.Trigger.checkTriggers(Trigger.java:266)
	at hudson.triggers.Trigger$Cron.doRun(Trigger.java:214)
	at hudson.triggers.SafeTimerTask.run(SafeTimerTask.java:54)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:304)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:178)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)