### PR TITLE
Use Unicode characters instead of Bitbucket emoji to avoid huge SVG in Hipchat

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -27,8 +27,8 @@ public class BitbucketRepository {
     public static final String BUILD_FINISH_SENTENCE = BUILD_FINISH_MARKER + " \n\n **%s** - %s";
     public static final String BUILD_REQUEST_MARKER = "test this please";
 
-    public static final String BUILD_SUCCESS_COMMENT =  ":star:SUCCESS";
-    public static final String BUILD_FAILURE_COMMENT = ":x:FAILURE";
+    public static final String BUILD_SUCCESS_COMMENT =  "✓ SUCCESS";
+    public static final String BUILD_FAILURE_COMMENT = "✕ FAILURE";
     private String projectPath;
     private BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;


### PR DESCRIPTION
Bitbucket must apply some CSS scaling on the svg emoji to make them appear small, as the original images are pretty large. See https://d3oaxc4q5k2d6q.cloudfront.net/m/7cb54ff512e6/emoji/img/x.svg for example.

Using these emoji in the success / failure messages was painful when also integrating Bitbucket with Hipchat. 
![screenshot from 2015-02-16 15 05 06](https://cloud.githubusercontent.com/assets/480131/6213215/a9d4843c-b5ed-11e4-8186-9da5bc7dca6e.png)

I propose using Unicode characters to bypass this issue.
This is mainly a suggestion, but it would make the life of Hipchat users easier.
 