### PR TITLE
Replace utf symbols in bulid comments with HTML entities.

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -27,8 +27,8 @@ public class BitbucketRepository {
     public static final String BUILD_FINISH_SENTENCE = BUILD_FINISH_MARKER + " \n\n **%s** - %s";
     public static final String BUILD_REQUEST_MARKER = "test this please";
 
-    public static final String BUILD_SUCCESS_COMMENT =  "✓ SUCCESS";
-    public static final String BUILD_FAILURE_COMMENT = "✕ FAILURE";
+    public static final String BUILD_SUCCESS_COMMENT =  "&#10004; SUCCESS";
+    public static final String BUILD_FAILURE_COMMENT = "&#10006; FAILURE";
     private String projectPath;
     private BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;
@@ -113,7 +113,7 @@ public class BitbucketRepository {
     }
 
     private boolean isBuildTarget(BitbucketPullRequestResponseValue pullRequest) {
-    	
+
         boolean shouldBuild = true;
         if (pullRequest.getState() != null && pullRequest.getState().equals("OPEN")) {
             if (isSkipBuild(pullRequest.getTitle())) {
@@ -126,10 +126,10 @@ public class BitbucketRepository {
             String owner = destination.getRepository().getOwnerName();
             String repositoryName = destination.getRepository().getRepositoryName();
             String destinationCommit = destination.getCommit().getHash();
-            
+
             String id = pullRequest.getId();
             List<BitbucketPullRequestComment> comments = client.getPullRequestComments(owner, repositoryName, id);
-            
+
             if (comments != null) {
                 Collections.sort(comments);
                 Collections.reverse(comments);
@@ -162,16 +162,16 @@ public class BitbucketRepository {
                         //first check source commit -- if it doesn't match, just move on. If it does, investigate further.
                         if (sourceCommitMatch.equalsIgnoreCase(sourceCommit)) {
                             // if we're checking destination commits, and if this doesn't match, then move on.
-                            if (this.trigger.getCheckDestinationCommit() 
+                            if (this.trigger.getCheckDestinationCommit()
                                     && (!destinationCommitMatch.equalsIgnoreCase(destinationCommit))) {
                             	continue;
                             }
-                            
+
                             shouldBuild = false;
                             break;
-                        } 
+                        }
                     }
-                    
+
                     if (content.contains(BUILD_REQUEST_MARKER.toLowerCase())) {
                         shouldBuild = true;
                         break;


### PR DESCRIPTION
`&#10004;` - http://unicode-table.com/en/search/?q=10004
`&#10006;` - http://unicode-table.com/en/search/?q=10006

closes #43 