### PR TITLE
Remove build result marker symbol

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -27,8 +27,8 @@ public class BitbucketRepository {
     public static final String BUILD_FINISH_SENTENCE = BUILD_FINISH_MARKER + " \n\n **%s** - %s";
     public static final String BUILD_REQUEST_MARKER = "test this please";
 
-    public static final String BUILD_SUCCESS_COMMENT =  "&#10004; SUCCESS";
-    public static final String BUILD_FAILURE_COMMENT = "&#10006; FAILURE";
+    public static final String BUILD_SUCCESS_COMMENT =  "SUCCESS";
+    public static final String BUILD_FAILURE_COMMENT = "FAILURE";
     private String projectPath;
     private BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;


### PR DESCRIPTION
Fix Build Result marker(SUCCESS / FAILURE).
It's a source of trouble. My simple answer is remove marker.

**Before**
![before_](https://cloud.githubusercontent.com/assets/818452/8765019/3cf9eff4-2e34-11e5-827c-cca8aa3a6dac.png)

**After**

![after_](https://cloud.githubusercontent.com/assets/818452/8765020/3ea4040c-2e34-11e5-8e03-c995e9f54fcc.png)