### PR TITLE
Use default parameters when triggering builds.

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -121,7 +121,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
 
     public QueueTaskFuture<?> startJob(BitbucketCause cause) {
-        Map<String, ParameterValue> values = new HashMap<String, ParameterValue>();
+        Map<String, ParameterValue> values = this.getDefaultParameters();
         values.put("sourceBranch", new StringParameterValue("sourceBranch", cause.getSourceBranch()));
         values.put("targetBranch", new StringParameterValue("targetBranch", cause.getTargetBranch()));
         values.put("repositoryOwner", new StringParameterValue("repositoryOwner", cause.getRepositoryOwner()));


### PR DESCRIPTION
I have some build parameters that have to be set in order for pull requests to be able to build, the defaults are set to work well for the PR building but they weren't being applied, I made this change in order to apply them and it's working for me when manually installed