### PR TITLE
Make posting comments on Pull Requests optional

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -31,7 +31,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String ciSkipPhrases;
     private final boolean checkDestinationCommit;
     private final boolean approveIfSuccess;
-    
+    private final boolean postPRComment;
+
     transient private BitbucketPullRequestsBuilder bitbucketPullRequestsBuilder;
 
     @Extension
@@ -47,7 +48,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String repositoryName,
             String ciSkipPhrases,
             boolean checkDestinationCommit,
-            boolean approveIfSuccess
+            boolean approveIfSuccess,
+            boolean postPRComment
             ) throws ANTLRException {
         super(cron);
         this.projectPath = projectPath;
@@ -59,6 +61,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.ciSkipPhrases = ciSkipPhrases;
         this.checkDestinationCommit = checkDestinationCommit;
         this.approveIfSuccess = approveIfSuccess;
+        this.postPRComment = postPRComment;
     }
 
     public String getProjectPath() {
@@ -88,13 +91,17 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     public String getCiSkipPhrases() {
         return ciSkipPhrases;
     }
-    
+
     public boolean getCheckDestinationCommit() {
     	return checkDestinationCommit;
     }
 
     public boolean getApproveIfSuccess() {
         return approveIfSuccess;
+    }
+
+    public boolean getPostPRComment() {
+        return postPRComment;
     }
 
     @Override

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuilds.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuilds.java
@@ -56,8 +56,10 @@ public class BitbucketBuilds {
         else {
             buildUrl = rootUrl + build.getUrl();
         }
-        repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
-        repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl);
+        if ( this.trigger.getPostPRComment() ) {
+          repository.deletePullRequestComment(cause.getPullRequestId(), cause.getBuildStartCommentId());
+          repository.postFinishedComment(cause.getPullRequestId(), cause.getSourceCommitHash(), cause.getDestinationCommitHash(), result == Result.SUCCESS, buildUrl);
+        }
         if ( this.trigger.getApproveIfSuccess() && result == Result.SUCCESS ) {
             this.repository.postPullRequestApproval(cause.getPullRequestId());
         }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -70,7 +70,10 @@ public class BitbucketRepository {
 
     public void addFutureBuildTasks(Collection<BitbucketPullRequestResponseValue> pullRequests) {
         for(BitbucketPullRequestResponseValue pullRequest : pullRequests) {
-            String commentId = postBuildStartCommentTo(pullRequest);
+            String commentId = "";
+            if ( this.trigger.getPostPRComment()) {
+              commentId = postBuildStartCommentTo(pullRequest);
+            }
             if ( this.trigger.getApproveIfSuccess() ) {
                 deletePullRequestApproval(pullRequest.getId());
             }

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -23,4 +23,8 @@
   <f:entry title="Approve if build success?" field="approveIfSuccess">
     <f:checkbox />
   </f:entry>
+  <f:entry title="Post Comments to Pull Request?" field="postPRComment">
+    <f:checkbox />
+  </f:entry>
+
 </j:jelly>


### PR DESCRIPTION
For our workflow it would be great if the plugin didn't leave any comments in bitbucket PR - Since we rebuild on each commit to targetBranch, our PR page quickly gets cluttered with Build notifications, causing us to miss out on actual PR discussion. (we have jenkins sending us notifications via different means)
