### PR TITLE
Add support for credentials from the Jenkins credentials store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target
+*.iml
+.idea
+dependency-reduced-pom.xml

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -1,12 +1,17 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
 import antlr.ANTLRException;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.RevisionParameterAction;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
+import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -17,6 +22,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
+
 /**
  * Created by nishio
  */
@@ -24,8 +31,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private static final Logger logger = Logger.getLogger(BitbucketBuildTrigger.class.getName());
     private final String projectPath;
     private final String cron;
-    private final String username;
-    private final String password;
+    private final String credentialsId;
     private final String repositoryOwner;
     private final String repositoryName;
     private final String ciSkipPhrases;
@@ -41,8 +47,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     public BitbucketBuildTrigger(
             String projectPath,
             String cron,
-            String username,
-            String password,
+            String credentialsId,
             String repositoryOwner,
             String repositoryName,
             String ciSkipPhrases,
@@ -52,8 +57,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         super(cron);
         this.projectPath = projectPath;
         this.cron = cron;
-        this.username = username;
-        this.password = password;
+        this.credentialsId = credentialsId;
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.ciSkipPhrases = ciSkipPhrases;
@@ -69,12 +73,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         return this.cron;
     }
 
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
+    public String getCredentialsId() {
+        return credentialsId;
     }
 
     public String getRepositoryOwner() {
@@ -179,6 +179,13 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             save();
             return super.configure(req, json);
+        }
+
+        public ListBoxModel doFillCredentialsIdItems() {
+            return new StandardListBoxModel()
+                    .withEmptySelection()
+                    .withMatching(instanceOf(UsernamePasswordCredentials.class),
+                            CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class));
         }
     }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -32,6 +32,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private final String projectPath;
     private final String cron;
     private final String credentialsId;
+    private final String username;
+    private final String password;
     private final String repositoryOwner;
     private final String repositoryName;
     private final String ciSkipPhrases;
@@ -48,6 +50,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             String projectPath,
             String cron,
             String credentialsId,
+            String username,
+            String password,
             String repositoryOwner,
             String repositoryName,
             String ciSkipPhrases,
@@ -58,6 +62,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         this.projectPath = projectPath;
         this.cron = cron;
         this.credentialsId = credentialsId;
+        this.username = username;
+        this.password = password;
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.ciSkipPhrases = ciSkipPhrases;
@@ -75,6 +81,14 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public String getCredentialsId() {
         return credentialsId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
     }
 
     public String getRepositoryOwner() {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -45,10 +45,17 @@ public class BitbucketRepository {
 
     public void init() {
         trigger = this.builder.getTrigger();
+        String username = trigger.getUsername();
+        String password = trigger.getPassword();
         StandardUsernamePasswordCredentials credentials = getCredentials(trigger.getCredentialsId());
+        if (credentials != null) {
+            username = credentials.getUsername();
+            password = credentials.getPassword().getPlainText();
+        }
+
         client = new ApiClient(
-                credentials.getUsername(),
-                credentials.getPassword().getPlainText(),
+                username,
+                password,
                 trigger.getRepositoryOwner(),
                 trigger.getRepositoryName());
     }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -10,6 +10,12 @@ import java.util.regex.Pattern;
 
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
 
 /**
  * Created by nishio
@@ -39,9 +45,10 @@ public class BitbucketRepository {
 
     public void init() {
         trigger = this.builder.getTrigger();
+        StandardUsernamePasswordCredentials credentials = getCredentials(trigger.getCredentialsId());
         client = new ApiClient(
-                trigger.getUsername(),
-                trigger.getPassword(),
+                credentials.getUsername(),
+                credentials.getPassword().getPlainText(),
                 trigger.getRepositoryOwner(),
                 trigger.getRepositoryName());
     }
@@ -191,5 +198,13 @@ public class BitbucketRepository {
             }
         }
         return false;
+    }
+
+    private StandardUsernamePasswordCredentials getCredentials(String credentialsId) {
+        return CredentialsMatchers
+                .firstOrNull(
+                        CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class),
+                        CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId),
+                                instanceOf(UsernamePasswordCredentials.class)));
     }
 }

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -5,6 +5,12 @@
   <f:entry title="${%Credentials}" field="credentialsId">
       <c:select/>
   </f:entry>
+  <f:entry title="Bitbucket BasicAuth Username" field="username">
+    <f:textbox />
+  </f:entry>
+  <f:entry title="Bitbucket BasicAuth Password" field="password">
+    <f:password />
+  </f:entry>
   <f:entry title="RepositoryOwner" field="repositoryOwner">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -1,12 +1,9 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="Cron" field="cron">
     <f:textbox />
   </f:entry>
-  <f:entry title="Bitbucket BasicAuth Username" field="username">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="Bitbucket BasicAuth Password" field="password">
-    <f:password />
+  <f:entry title="${%Credentials}" field="credentialsId">
+      <c:select/>
   </f:entry>
   <f:entry title="RepositoryOwner" field="repositoryOwner">
     <f:textbox />


### PR DESCRIPTION
Support credentials by allowing UsernamePasswordCredentials to be picked when configuring BitbucketBuildTrigger and changed BitbucketRepository to use the credentials when setting up the ApiClient.

Closes: Add support for Credentials plugin #33