### PR TITLE
Add support for credentials from the Jenkins credentials store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>
   <name>Bitbucket Pullrequest Builder Plugin</name>
-  <version>1.4.14-SNAPSHOT</version>
+  <version>1.4.15</version>
   <description>This Jenkins plugin builds pull requests from Bitbucket.org and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin</url>    

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -1,12 +1,17 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
 import antlr.ANTLRException;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import hudson.Extension;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.git.RevisionParameterAction;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
+import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -17,6 +22,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
+
 /**
  * Created by nishio
  */
@@ -24,6 +31,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     private static final Logger logger = Logger.getLogger(BitbucketBuildTrigger.class.getName());
     private final String projectPath;
     private final String cron;
+    private final String credentialsId;
     private final String username;
     private final String password;
     private final String repositoryOwner;
@@ -45,6 +53,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     public BitbucketBuildTrigger(
             String projectPath,
             String cron,
+            String credentialsId,
             String username,
             String password,
             String repositoryOwner,
@@ -60,6 +69,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         super(cron);
         this.projectPath = projectPath;
         this.cron = cron;
+        this.credentialsId = credentialsId;
         this.username = username;
         this.password = password;
         this.repositoryOwner = repositoryOwner;
@@ -79,6 +89,10 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public String getCron() {
         return this.cron;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
     }
 
     public String getUsername() {
@@ -207,6 +221,13 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
             save();
             return super.configure(req, json);
+        }
+
+        public ListBoxModel doFillCredentialsIdItems() {
+            return new StandardListBoxModel()
+                    .withEmptySelection()
+                    .withMatching(instanceOf(UsernamePasswordCredentials.class),
+                            CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class));
         }
     }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
@@ -2,10 +2,15 @@ package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
 import hudson.model.AbstractProject;
+
+import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import java.util.Collection;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.apache.commons.codec.binary.Hex;
 
 /**
@@ -54,12 +59,20 @@ public class BitbucketPullRequestsBuilder {
         return this.project;
     }        
     
+    /**
+     * Return MD5 hashed full project name or full project name, if MD5 hash provider inaccessible
+     * @return unique project id
+     */
     public String getProjectId() {
       try {
         final MessageDigest MD5 = MessageDigest.getInstance("MD5");
         return new String(Hex.encodeHex(MD5.digest(this.project.getFullName().getBytes("UTF-8"))));
-      } catch (Exception exc) {
-        logger.severe(exc.toString());
+      } catch (NoSuchAlgorithmException exc) {
+        logger.log(Level.WARNING, "Failed to produce hash", exc);
+        exc.printStackTrace();
+      } catch (UnsupportedEncodingException exc) {
+        logger.log(Level.WARNING, "Failed to produce hash", exc);
+        exc.printStackTrace();
       }
       return this.project.getFullName();
     }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -13,11 +13,17 @@ import java.util.LinkedList;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.SCMSourceOwners;
 import org.apache.commons.lang.StringUtils;
+
+import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
 
 /**
  * Created by nishio
@@ -34,26 +40,46 @@ public class BitbucketRepository {
     private BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;
     private ApiClient client;
-
+    
     public BitbucketRepository(String projectPath, BitbucketPullRequestsBuilder builder) {
         this.projectPath = projectPath;
         this.builder = builder;
     }
 
     public void init() {
-        this.init(null);
+        this.init(null, null);
+    }
+    
+    public <T extends ApiClient.HttpClientFactory> void init(Class<T> httpFactory) {
+        this.init(null, httpFactory);
     }
     
     public void init(ApiClient client) {
+        this.init(client, null);
+    }
+    
+    public <T extends ApiClient.HttpClientFactory> void init(ApiClient client, Class<T> httpFactory) {
         this.trigger = this.builder.getTrigger();
-        this.client = (client == null) ? new ApiClient(
-                trigger.getUsername(),
-                trigger.getPassword(),
+        
+        if (client == null) {                      
+            String username = trigger.getUsername();
+            String password = trigger.getPassword();            
+            StandardUsernamePasswordCredentials credentials = getCredentials(trigger.getCredentialsId());
+            if (credentials != null) {
+                username = credentials.getUsername();
+                password = credentials.getPassword().getPlainText();
+            }            
+            this.client = new ApiClient(
+                username,
+                password,
                 trigger.getRepositoryOwner(),
                 trigger.getRepositoryName(),
                 trigger.getCiKey(),
-                trigger.getCiName()
-        ) : client;
+                trigger.getCiName(),
+                httpFactory
+            );
+            
+        } else this.client = client;
     }
 
     public Collection<Pullrequest> getTargetPullRequests() {
@@ -66,6 +92,10 @@ public class BitbucketRepository {
             }
         }
         return targetPullRequests;
+    }
+    
+    public ApiClient getClient() {
+      return this.client;
     }
 
     public void addFutureBuildTasks(Collection<Pullrequest> pullRequests) {
@@ -266,5 +296,13 @@ public class BitbucketRepository {
           BitbucketBuildFilter.InstanceBySCM(sources, this.trigger.getBranchesFilter());
         
         return filter.approved(cause);
+    }
+
+    private StandardUsernamePasswordCredentials getCredentials(String credentialsId) {
+        return CredentialsMatchers
+                .firstOrNull(
+                        CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class),
+                        CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId),
+                                instanceOf(UsernamePasswordCredentials.class)));
     }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -54,7 +54,7 @@ public class BitbucketRepository {
         this.init(null, null);
     }
     
-    public <T extends ApiClient.HttpClientFactory> void init(Class<T> httpFactory) {
+    public <T extends ApiClient.HttpClientFactory> void init(T httpFactory) {
         this.init(null, httpFactory);
     }
     
@@ -62,7 +62,7 @@ public class BitbucketRepository {
         this.init(client, null);
     }
     
-    public <T extends ApiClient.HttpClientFactory> void init(ApiClient client, Class<T> httpFactory) {
+    public <T extends ApiClient.HttpClientFactory> void init(ApiClient client, T httpFactory) {
         this.trigger = this.builder.getTrigger();
         
         if (client == null) {                      

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -9,18 +9,22 @@ import java.util.logging.Logger;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BuildState;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
+
 import java.util.LinkedList;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.SCMSourceOwners;
+
 import org.apache.commons.lang.StringUtils;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
@@ -299,6 +303,7 @@ public class BitbucketRepository {
     }
 
     private StandardUsernamePasswordCredentials getCredentials(String credentialsId) {
+        if (null == credentialsId) return null;
         return CredentialsMatchers
                 .firstOrNull(
                         CredentialsProvider.lookupCredentials(StandardUsernamePasswordCredentials.class),

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
@@ -71,23 +71,14 @@ public class ApiClient {
         String username, String password, 
         String owner, String repositoryName, 
         String key, String name, 
-        Class<T> httpFactory
+        T httpFactory
     ) {
         this.credentials = new UsernamePasswordCredentials(username, password);
         this.owner = owner;
         this.repositoryName = repositoryName;
         this.key = key;
-        this.name = name;
-        
-        try {
-            this.factory = (httpFactory != null) ? httpFactory.newInstance() : HttpClientFactory.INSTANCE;
-        } catch(InstantiationException e) {
-            logger.log(Level.WARNING, "failed new instance of {0}: {1} ", new Object[] { httpFactory.getName(), e });
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
-            logger.log(Level.WARNING, "failed new instance of {0}: {1} ", new Object[] { httpFactory.getName(), e });
-            e.printStackTrace();
-      }
+        this.name = name;        
+        this.factory = httpFactory != null ? httpFactory : HttpClientFactory.INSTANCE;
     }
 
     public List<Pullrequest> getPullRequests() {

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -1,6 +1,9 @@
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
   <f:entry title="Cron" field="cron">
     <f:textbox />
+  </f:entry>
+  <f:entry title="${%Credentials}" field="credentialsId">
+      <c:select/>
   </f:entry>
   <f:entry title="Bitbucket BasicAuth Username" field="username">
     <f:textbox />

--- a/src/test/java/BitbucketBuildFilterTest.java
+++ b/src/test/java/BitbucketBuildFilterTest.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildFilter;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketCause;
@@ -10,9 +5,7 @@ import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketPullRequ
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketRepository;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
-import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -25,8 +18,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 
 /**
- *
- * @author maxvodo
+ * Tests
  */
 public class BitbucketBuildFilterTest {
   
@@ -287,25 +279,5 @@ public class BitbucketBuildFilterTest {
     String myBuildKey = "902f259e962ff16100843123480a0970";
     for(Pullrequest.Comment comment : comments)
       assertFalse(repo.hasMyBuildTagInTTPComment(comment.getContent(), myBuildKey));
-  }
-  
-  //@Test
-  @WithoutJenkins
-  public void ttpCommentTest() {    
-    ApiClient client = EasyMock.createNiceMock(ApiClient.class);
-    Collection<List<Pullrequest>> prs = new LinkedList<List<Pullrequest>>();
-    
-    prs.add(Arrays.asList(new Pullrequest[] {
-      new Pullrequest()
-    }));
-    
-    for(List<Pullrequest> pr : prs) EasyMock.expect(client.getPullRequests()).andReturn(pr).times(1);
-    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class);
-    EasyMock.replay(client, builder);
-    
-    BitbucketRepository repo = new BitbucketRepository("", builder);
-    repo.init(client);
-    
-    Collection<Pullrequest> targetPRs = repo.getTargetPullRequests();
   }
 }

--- a/src/test/java/BitbucketBuildFilterTest.java
+++ b/src/test/java/BitbucketBuildFilterTest.java
@@ -5,17 +5,20 @@ import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketPullRequ
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketRepository;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
+
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
+
 import jenkins.plugins.git.AbstractGitSCMSource;
-import org.easymock.*;
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
+
+import org.easymock.*;
+import org.junit.Test;
+import org.junit.Rule;
+import static org.junit.Assert.*;
 
 /**
  * Tests

--- a/src/test/java/BitbucketBuildRepositoryTest.java
+++ b/src/test/java/BitbucketBuildRepositoryTest.java
@@ -1,25 +1,41 @@
 
+import antlr.ANTLRException;
+
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketPullRequestsBuilder;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketRepository;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
+
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Collection;
 import org.easymock.*;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.junit.Assert;
 import org.jvnet.hudson.test.JenkinsRule;
+
 import jenkins.model.Jenkins;
+import org.jvnet.hudson.test.WithoutJenkins;
+
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.httpclient.Credentials;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpState;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.commons.httpclient.auth.AuthScope;
-import org.junit.Assert;
 
 
 interface ICredentialsInterceptor {
@@ -149,5 +165,102 @@ public class BitbucketBuildRepositoryTest {
     repo.init(httpFactory.getClass());        
     
     try { repo.postPullRequestApproval("prId"); } catch(Error e) { assertTrue(e instanceof AssertionError); }                
+  }
+  
+  class MD5HasherFunction implements Function<String, String> {       
+    protected final MessageDigest MD5;
+    public MD5HasherFunction(MessageDigest md5) { this.MD5 = md5; }
+    public String apply(String f) {
+      try { return new String(Hex.encodeHex(MD5.digest(f.getBytes("UTF-8")))); } catch(UnsupportedEncodingException e) { }
+      return null;
+    }
+  }
+  
+  class SHA1HasherFunction implements Function<String, String> {       
+    protected final MessageDigest SHA1;
+    public SHA1HasherFunction(MessageDigest sha1) { this.SHA1 = sha1; }
+    public String apply(String f) {
+      try { return new String(Hex.encodeHex(SHA1.digest(f.getBytes("UTF-8")))); } catch(UnsupportedEncodingException e) { }
+      return null;
+    }
+  }
+  
+  @Test  
+  @WithoutJenkins
+  public void repositoryProjectIdTest() throws ANTLRException, NoSuchAlgorithmException, UnsupportedEncodingException {
+    BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
+      "", "@hourly",
+      "JenkinsCID",
+      "foo",
+      "bar",
+      "", "",
+      "", true,
+      "jenkins", "Jenkins", "",
+      true, 
+      true
+    );
+    
+    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
+    EasyMock.expect(builder.getTrigger()).andReturn(trigger).anyTimes();
+    
+    final MessageDigest MD5 = MessageDigest.getInstance("MD5");
+    
+    String[] projectIds = new String[] { 
+      "one", 
+      "Second project",
+      "Project abstract 1.1",
+      "Good project, careated at " + (new java.util.Date()).toString(),      
+    };   
+    
+    Collection<String> hashedProjectIdsCollection = Collections2.transform(Arrays.asList(projectIds), new MD5HasherFunction(MD5));
+    String[] hashedPojectIds = hashedProjectIdsCollection.toArray(new String[hashedProjectIdsCollection.size()]);
+    
+    for(String projectId : hashedPojectIds) {
+      EasyMock.expect(builder.getProjectId()).andReturn(projectId).times(1);
+    }        
+    EasyMock.replay(builder);
+    
+    BitbucketRepository repo = new BitbucketRepository("", builder);
+    repo.init();       
+    
+    for(String projectId : projectIds) {
+      String hashMD5 = new String(Hex.encodeHex(MD5.digest(projectId.getBytes("UTF-8"))));
+      String buildStatusKey = repo.getClient().buildStatusKey(builder.getProjectId());
+      
+      assertTrue(buildStatusKey.length() <= ApiClient.MAX_KEY_SIZE_BB_API);
+      assertEquals(buildStatusKey, "jenkins-" + hashMD5);
+    }
+  }
+  
+  @Test  
+  @WithoutJenkins
+  public void triggerLongCIKeyTest() throws ANTLRException, NoSuchAlgorithmException {        
+    BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
+      "", "@hourly",
+      "JenkinsCID",
+      "foo",
+      "bar",
+      "", "",
+      "", true,
+      "jenkins-too-long-ci-key", "Jenkins", "",
+      true, 
+      true
+    );
+    
+    final MessageDigest MD5 = MessageDigest.getInstance("MD5");
+    final MessageDigest SHA1 = MessageDigest.getInstance("SHA1");
+    
+    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
+    EasyMock.expect(builder.getTrigger()).andReturn(trigger).anyTimes();
+    EasyMock.expect(builder.getProjectId()).andReturn((new MD5HasherFunction(MD5)).apply("projectId")).anyTimes();
+    EasyMock.replay(builder);       
+    
+    BitbucketRepository repo = new BitbucketRepository("", builder);
+    repo.init();
+    
+    String buildStatusKey = repo.getClient().buildStatusKey(builder.getProjectId());
+    assertTrue(buildStatusKey.length() <= ApiClient.MAX_KEY_SIZE_BB_API);
+    assertFalse(buildStatusKey.startsWith("jenkins-"));
+    assertEquals((new SHA1HasherFunction(SHA1)).apply("jenkins-too-long-ci-key" + "-" + builder.getProjectId()), buildStatusKey);
   }
 }

--- a/src/test/java/BitbucketBuildRepositoryTest.java
+++ b/src/test/java/BitbucketBuildRepositoryTest.java
@@ -1,0 +1,153 @@
+
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketBuildTrigger;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketPullRequestsBuilder;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.BitbucketRepository;
+import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+import org.easymock.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
+import jenkins.model.Jenkins;
+import org.apache.commons.httpclient.Credentials;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpState;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.junit.Assert;
+
+
+interface ICredentialsInterceptor {
+  void assertCredentials(Credentials actual);
+}
+
+/**
+ * Utility class for interceptor functionality
+ * @param <T> 
+ */
+class HttpClientInterceptor<T extends ICredentialsInterceptor> extends HttpClient {  
+  
+  class CredentialsInterceptor<T extends ICredentialsInterceptor> extends HttpState {
+    private final T interceptor;
+    public CredentialsInterceptor(T interceptor) { this.interceptor = interceptor; }
+    
+    @Override
+    public synchronized void setCredentials(AuthScope authscope, Credentials credentials) {      
+      super.setCredentials(authscope, credentials);
+      this.interceptor.assertCredentials(credentials);
+      throw new AssertionError();
+    }    
+  }  
+  
+  private final T interceptor;
+  public HttpClientInterceptor(T interceptor) { this.interceptor = interceptor; }
+  
+  @Override
+  public synchronized HttpState getState() { return new CredentialsInterceptor(this.interceptor); }  
+}
+
+/**
+ * Utility class for credentials assertion
+ * Used with 
+ * @author maxvodo
+ */
+class AssertCredentials implements ICredentialsInterceptor {
+  private final Credentials expected;
+  public AssertCredentials(Credentials expected) { this.expected = expected; }
+
+  public void assertCredentials(Credentials actual) {
+    if (actual == null) assertTrue(this.expected == null); 
+                   else assertTrue(this.expected != null);        
+
+    if (actual instanceof UsernamePasswordCredentials) {
+      UsernamePasswordCredentials actual_ = (UsernamePasswordCredentials)actual,
+                                  expected_ = (UsernamePasswordCredentials)this.expected;
+      assertNotNull(expected_);
+      Assert.assertArrayEquals(new Object[] {
+        actual_.getUserName(), actual_.getPassword()
+      }, new Object[] {
+        expected_.getUserName(), expected_.getPassword()
+      });
+    }
+  }      
+}
+
+/**
+ * Tests
+ */
+public class BitbucketBuildRepositoryTest {
+
+  @Rule
+  public JenkinsRule jRule = new JenkinsRule();  
+  
+  @Test  
+  public void repositorySimpleUserPasswordTest() throws Exception {
+    BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
+      "", "@hourly",
+      "JenkinsCID",
+      "foo",
+      "bar",
+      "", "",
+      "", true,
+      "", "", "",
+      true, 
+      true
+    );
+    
+    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
+    EasyMock.expect(builder.getTrigger()).andReturn(trigger).anyTimes();
+    EasyMock.replay(builder);
+    
+    ApiClient.HttpClientFactory httpFactory = EasyMock.createMock(ApiClient.HttpClientFactory.class);
+    EasyMock.expect(httpFactory.getInstanceHttpClient()).andReturn(
+      new HttpClientInterceptor(new AssertCredentials(new UsernamePasswordCredentials("foo", "bar")))
+    ).anyTimes();
+    EasyMock.replay(httpFactory);            
+    
+    BitbucketRepository repo = new BitbucketRepository("", builder);
+    repo.init(httpFactory.getClass());
+    
+    try { repo.postPullRequestApproval("prId"); } catch(Error e) { assertTrue(e instanceof AssertionError); }
+  }
+  
+  @Test  
+  public void repositoryCtorWithTriggerTest() throws Exception {
+    BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
+      "", "@hourly",
+      "JenkinsCID",
+      "foo",
+      "bar",
+      "", "",
+      "", true,
+      "", "", "",
+      true, 
+      true
+    );          
+    
+    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
+    EasyMock.expect(builder.getTrigger()).andReturn(trigger).anyTimes();
+    EasyMock.replay(builder);
+    
+    CredentialsStore store = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+    assertNotNull(store);
+    store.addCredentials(Domain.global(), new UsernamePasswordCredentialsImpl(
+      CredentialsScope.GLOBAL, "JenkinsCID", "description", "username", "password"
+    ));
+    
+    ApiClient.HttpClientFactory httpFactory = EasyMock.createMock(ApiClient.HttpClientFactory.class);
+    EasyMock.expect(httpFactory.getInstanceHttpClient()).andReturn(
+      new HttpClientInterceptor(new AssertCredentials(new UsernamePasswordCredentials("username", "password")))
+    ).anyTimes();
+    EasyMock.replay(httpFactory);  
+    
+    BitbucketRepository repo = new BitbucketRepository("", builder);
+    repo.init(httpFactory.getClass());        
+    
+    try { repo.postPullRequestApproval("prId"); } catch(Error e) { assertTrue(e instanceof AssertionError); }                
+  }
+}


### PR DESCRIPTION
By default we using username/password from original text fields (config.jelly).
If credentials ID provided in plugin settings - using them for BitBucket API auth.

Code from #64 reviewed and integrated into last master.
Resolve issue #33 and integrate #64 pull request.