### PR TITLE
Properly close connections to avoid TCP CLOSE_WAIT

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
@@ -244,6 +244,8 @@ public class ApiClient {
         } catch (IOException e) {
             logger.log(Level.WARNING, "Failed to send request.", e);
             e.printStackTrace();
+        } finally {
+          req.releaseConnection();
         }
         return null;
     }


### PR DESCRIPTION
Using HttpMethodBase.releaseConnection() for this stuff.
Must close issue #75.