### PR TITLE
Available "pullRequestAuthor" env variable (featured from #83)

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -164,6 +164,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     public QueueTaskFuture<?> startJob(BitbucketCause cause) {
         Map<String, ParameterValue> values = this.getDefaultParameters();
+        
         values.put("sourceBranch", new StringParameterValue("sourceBranch", cause.getSourceBranch()));
         values.put("targetBranch", new StringParameterValue("targetBranch", cause.getTargetBranch()));
         values.put("repositoryOwner", new StringParameterValue("repositoryOwner", cause.getRepositoryOwner()));
@@ -172,6 +173,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         values.put("destinationRepositoryOwner", new StringParameterValue("destinationRepositoryOwner", cause.getDestinationRepositoryOwner()));
         values.put("destinationRepositoryName", new StringParameterValue("destinationRepositoryName", cause.getDestinationRepositoryName()));
         values.put("pullRequestTitle", new StringParameterValue("pullRequestTitle", cause.getPullRequestTitle()));
+        values.put("pullRequestAuthor", new StringParameterValue("pullRequestAuthor", cause.getPullRequestAuthor()));
+        
         return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList(values.values())), new RevisionParameterAction(cause.getSourceCommitHash()));
     }
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketCause.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketCause.java
@@ -16,6 +16,7 @@ public class BitbucketCause extends Cause {
     private final String pullRequestTitle;
     private final String sourceCommitHash;
     private final String destinationCommitHash;
+    private final String pullRequestAuthor;
     public static final String BITBUCKET_URL = "https://bitbucket.org/";
 
     public BitbucketCause(String sourceBranch,
@@ -27,7 +28,8 @@ public class BitbucketCause extends Cause {
                           String destinationRepositoryName,
                           String pullRequestTitle,
                           String sourceCommitHash,
-                          String destinationCommitHash) {
+                          String destinationCommitHash,
+                          String pullRequestAuthor) {
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
         this.repositoryOwner = repositoryOwner;
@@ -38,6 +40,7 @@ public class BitbucketCause extends Cause {
         this.pullRequestTitle = pullRequestTitle;
         this.sourceCommitHash = sourceCommitHash;
         this.destinationCommitHash = destinationCommitHash;
+        this.pullRequestAuthor = pullRequestAuthor;
     }
 
     public String getSourceBranch() {
@@ -82,5 +85,9 @@ public class BitbucketCause extends Cause {
         description += this.getDestinationRepositoryName() + "/pull-request/" + this.getPullRequestId();
         description += "\">#" + this.getPullRequestId() + " " + this.getPullRequestTitle() + "</a>";
         return description;
+    }
+    
+    public String getPullRequestAuthor() {
+      return this.pullRequestAuthor;
     }
 }

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -117,7 +117,9 @@ public class BitbucketRepository {
                     pullRequest.getDestination().getRepository().getRepositoryName(),
                     pullRequest.getTitle(),
                     pullRequest.getSource().getCommit().getHash(),
-                    pullRequest.getDestination().getCommit().getHash());
+                    pullRequest.getDestination().getCommit().getHash(),
+                    pullRequest.getAuthor().getCombinedUsername()
+            );
             setBuildStatus(cause, BuildState.INPROGRESS, Jenkins.getInstance().getRootUrl());
             this.builder.getTrigger().startJob(cause);
         }
@@ -286,7 +288,8 @@ public class BitbucketRepository {
           pullRequest.getDestination().getRepository().getRepositoryName(),
           pullRequest.getTitle(),
           pullRequest.getSource().getCommit().getHash(),
-          pullRequest.getDestination().getCommit().getHash()
+          pullRequest.getDestination().getCommit().getHash(),
+          pullRequest.getAuthor().getCombinedUsername()
         );
         
         //@FIXME: Way to iterate over all available SCMSources

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/Pullrequest.java
@@ -28,6 +28,7 @@ public class Pullrequest {
     private String     updatedOn;
     private String     mergeCommit;
     private String     id;
+    private Author     author;
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Response {
@@ -233,6 +234,33 @@ public class Pullrequest {
             this.createdOn = createdOn;
         }
     }
+    
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Author {
+      private String username;
+      private String display_name;
+      public static final String COMBINED_NAME = "%s <@%s>";
+      
+      public String getUsername() {
+          return username;
+      }
+      public void setUsername(String username) {
+          this.username = username;
+      }
+      
+      @JsonProperty("display_name")
+      public String getDisplayName() {
+          return display_name;
+      }
+      
+      @JsonProperty("display_name")
+      public void setDisplayName(String display_name) {
+          this.display_name = display_name;
+      }
+      public String getCombinedUsername() {
+        return String.format(COMBINED_NAME, this.getDisplayName(), this.getUsername());
+      }
+    }
 
     //-------------------- only getters and setters follow -----------------
 
@@ -340,6 +368,14 @@ public class Pullrequest {
 
     public void setId(String id) {
         this.id = id;
+    }
+    
+    public Author getAuthor() {
+      return this.author;
+    }
+    
+    public void setAutohor(Author author) {
+      this.author = author;
     }
 
 }

--- a/src/test/java/BitbucketBuildFilterTest.java
+++ b/src/test/java/BitbucketBuildFilterTest.java
@@ -142,6 +142,26 @@ public class BitbucketBuildFilterTest {
   
   @Test
   @WithoutJenkins
+  public void authorFilter() {
+    BitbucketCause cause = EasyMock.createMock(BitbucketCause.class);
+    EasyMock.expect(cause.getTargetBranch()).andReturn("master").anyTimes();
+    EasyMock.expect(cause.getSourceBranch()).andReturn("feature-master").anyTimes();
+    EasyMock.expect(cause.getPullRequestAuthor()).andReturn("test").anyTimes();
+    EasyMock.replay(cause);
+    
+    for(String f : new String[] {"a:test", "a:r:^test", "d: s: a:", "a:", "a:foo a:test"}) {
+      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      assertTrue(filter.approved(cause));
+    }
+    
+    for(String f : new String[] {"s:feature-master", "d:master", "s:feature-master d: a:foo", "a:bar"}) {
+      BitbucketBuildFilter filter = BitbucketBuildFilter.InstanceByString(f);      
+      assertFalse(filter.approved(cause));
+    }
+  }
+  
+  @Test
+  @WithoutJenkins
   public void emptyGitSCMFilter() {
     BitbucketCause cause = EasyMock.createMock(BitbucketCause.class);
     EasyMock.expect(cause.getTargetBranch()).andReturn("master").anyTimes();


### PR DESCRIPTION
Env variable "pullRequestAuthor" contain two parts of author: full name of user and short username in format, like: "Some Doo @somedoo".
Add test for PR build filter: now we can filter also by author: "a:maxvodo" by example.