### PR TITLE
Use JenkinsLocationConfiguration to fetch the URL.

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuilds.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuilds.java
@@ -5,6 +5,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Result;
 import jenkins.model.Jenkins;
+import jenkins.model.JenkinsLocationConfiguration;
 
 import java.io.IOException;
 import java.util.logging.Level;
@@ -49,7 +50,8 @@ public class BitbucketBuilds {
             return;
         }
         Result result = build.getResult();
-        String rootUrl = Jenkins.getInstance().getRootUrl();
+        JenkinsLocationConfiguration globalConfig = new JenkinsLocationConfiguration();
+        String rootUrl = globalConfig.getUrl();
         String buildUrl = "";
         if (rootUrl == null) {
             logger.warning("PLEASE SET JENKINS ROOT URL IN GLOBAL CONFIGURATION FOR BUILD STATE REPORTING");


### PR DESCRIPTION
`Jenkins.getInstance().getRootUrl()` returns `null` despite the URL
being set through the web UI. `JenkinsLocationConfiguration.getUrl()`
returns the correct URL.

Thanks Esteban Angee on StackOverflow:
http://stackoverflow.com/questions/15949946/programatically-access-jenkins-url

[Resolves #19]

Before/after showing my fix working:
![img](http://i.imgur.com/rrVMKFc.png)