### PR TITLE
Support Jenkins2 pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.4</version><!-- which version of Jenkins is this plugin built against? -->         
+    <version>1.596.1</version>
   </parent>
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -14,6 +14,7 @@ import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -33,7 +34,7 @@ import static com.cloudbees.plugins.credentials.CredentialsMatchers.instanceOf;
 /**
  * Created by nishio
  */
-public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
+public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
     private static final Logger logger = Logger.getLogger(BitbucketBuildTrigger.class.getName());
     private final String projectPath;
     private final String cron;
@@ -153,7 +154,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
     }
 
     @Override
-    public void start(AbstractProject<?, ?> project, boolean newInstance) {
+    public void start(Job<?, ?> project, boolean newInstance) {
         try {
             this.bitbucketPullRequestsBuilder = BitbucketPullRequestsBuilder.getBuilder();
             this.bitbucketPullRequestsBuilder.setProject(project);
@@ -175,6 +176,16 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
         return this.bitbucketPullRequestsBuilder;
     }
 
+    private ParameterizedJobMixIn retrieveScheduleJob(final Job<?, ?> job) {
+        // TODO 1.621+ use standard method
+        return new ParameterizedJobMixIn() {
+            @Override
+            protected Job asJob() {
+                return job;
+            }
+        };
+    }
+
     public QueueTaskFuture<?> startJob(BitbucketCause cause) {
         Map<String, ParameterValue> values = this.getDefaultParameters();
 
@@ -183,7 +194,10 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
             abortRunningJobsThatMatch(cause);
         }
 
-        return this.job.scheduleBuild2(0, cause, new ParametersAction(new ArrayList(values.values())), new RevisionParameterAction(cause.getSourceCommitHash()));
+        return retrieveScheduleJob(this.job).scheduleBuild2(0,
+                new CauseAction(cause),
+                new ParametersAction(new ArrayList(values.values())),
+                new RevisionParameterAction(cause.getSourceCommitHash()));
     }
 
     private void cancelPreviousJobsInQueueThatMatch(@Nonnull BitbucketCause bitbucketCause) {
@@ -239,11 +253,8 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
     @Override
     public void run() {
-        if(this.getBuilder().getProject().isDisabled()) {
-            logger.info("Build Skip.");
-        } else {
-            this.bitbucketPullRequestsBuilder.run();
-        }
+        logger.log(Level.INFO, "TODO: check if project is disabled before calling bitbucketPullRequestsBuilder.run()");
+        this.bitbucketPullRequestsBuilder.run();
         this.getDescriptor().save();
     }
 
@@ -259,7 +270,7 @@ public class BitbucketBuildTrigger extends Trigger<AbstractProject<?, ?>> {
 
         @Override
         public boolean isApplicable(Item item) {
-            return true;
+            return item instanceof Job && item instanceof ParameterizedJobMixIn.ParameterizedJob;
         }
 
         @Override

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -253,9 +253,13 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
 
     @Override
     public void run() {
-        logger.log(Level.INFO, "TODO: check if project is disabled before calling bitbucketPullRequestsBuilder.run()");
-        this.bitbucketPullRequestsBuilder.run();
-        this.getDescriptor().save();
+    	Job<?,?> project = this.getBuilder().getProject();
+    	if (project instanceof AbstractProject && ((AbstractProject)project).isDisabled()) {
+    		logger.info("Build Skip.");
+    	} else {
+    		this.bitbucketPullRequestsBuilder.run();
+            this.getDescriptor().save();
+    	}
     }
 
     @Override

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketPullRequestsBuilder.java
@@ -1,7 +1,6 @@
 package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder;
 
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Pullrequest;
-import hudson.model.AbstractProject;
 
 import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
@@ -11,6 +10,7 @@ import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import hudson.model.Job;
 import org.apache.commons.codec.binary.Hex;
 
 /**
@@ -18,7 +18,7 @@ import org.apache.commons.codec.binary.Hex;
  */
 public class BitbucketPullRequestsBuilder {
     private static final Logger logger = Logger.getLogger(BitbucketBuildTrigger.class.getName());
-    private AbstractProject<?, ?> project;
+    private Job<?, ?> project;
     private BitbucketBuildTrigger trigger;
     private BitbucketRepository repository;
     private BitbucketBuilds builds;
@@ -47,7 +47,7 @@ public class BitbucketPullRequestsBuilder {
         return this;
     }
 
-    public void setProject(AbstractProject<?, ?> project) {
+    public void setProject(Job<?, ?> project) {
         this.project = project;
     }
 
@@ -55,7 +55,7 @@ public class BitbucketPullRequestsBuilder {
         this.trigger = trigger;
     }
 
-    public AbstractProject<?, ?> getProject() {
+    public Job<?, ?> getProject() {
         return this.project;
     }        
     
@@ -73,6 +73,7 @@ public class BitbucketPullRequestsBuilder {
         logger.log(Level.WARNING, "Failed to produce hash", exc);
       }
       return this.project.getFullName();
+
     }
 
     public BitbucketBuildTrigger getTrigger() {


### PR DESCRIPTION
Replace use of AbstractProject with Job to fix ClassCastException thrown when using the plugin in a pipeline job

~~**Note** The previous behaviour to skip the build if the project was disabled is currently not implemented. The `Job` class does not have the method `AbstractProject.isDisabled()`, so it remains to find an alternative way to do the check...~~

Fixes #94 
