### PR TITLE
Add support for Jenkins pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
       <version>2.2.4</version>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>symbol-annotation</artifactId>
+      <version>1.1</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>14.0-rc3</version>

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -17,6 +17,7 @@ import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -56,7 +57,6 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
 
     transient private BitbucketPullRequestsBuilder bitbucketPullRequestsBuilder;
 
-    @Extension
     public static final BitbucketBuildTriggerDescriptor descriptor = new BitbucketBuildTriggerDescriptor();
 
     @DataBoundConstructor
@@ -299,6 +299,8 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
         super.stop();
     }
 
+    @Extension
+    @Symbol("bitbucketpr")
     public static final class BitbucketBuildTriggerDescriptor extends TriggerDescriptor {
         public BitbucketBuildTriggerDescriptor() {
             load();


### PR DESCRIPTION
This will make it possible to configure pull request triggers in Jenkins pipelines. Please change the symbol value (bitbucketpr) to whatever you thinks fit.

The configuration in a Jenkinsfile can look like:

pipeline {
    agent any
    triggers{
        bitbucketpr(projectPath:'<BIT_BUCKET_PATH>',
                    cron:'H/15 * * * *',
                    credentialsId:'',
                    username:'',
                    password:'',
                    repositoryOwner:'',
                    repositoryName:'',
                    branchesFilter:'',
                    branchesFilterBySCMIncludes:false,
                    ciKey:'',
                    ciName:'',
                    ciSkipPhrases:'',
                    checkDestinationCommit:false,
                    approveIfSuccess:false,
                    cancelOutdatedJobs:true,
                    commentTrigger:'')
    }