### PR TITLE
Add general setup help

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 
 jdk:
   - openjdk7
-  - oraclejdk7
+  - oraclejdk8
 
 script:
   mvn install -U

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/help.html
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/help.html
@@ -1,0 +1,9 @@
+<div>
+  <p>Builds pull requests from Bitbucket.org and will report the test results.</p>
+  <p>This plugin requires Git SCM plugin configured as follows:
+    <ul>
+      <li>Add Repository URL, git@bitbucket.org:${repositoryOwner}/${repositoryName}.git</li>
+      <li>In Branch Specifier, type */${sourceBranch}
+    </ul>   
+
+</div>


### PR DESCRIPTION
After trying to configure this plugin without success, I found out I had incorrectly configured the branch specifier for the Git plugin. 

This PR adds inline help text for the plugin that details the configuration of the Git SCM plugin for this plugin to work.