### PR TITLE
[Fixes #137] Move from basic auth (which no longer appears to work) to OAuth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <artifactId>bitbucket-pullrequest-builder</artifactId>
   <name>Bitbucket Pullrequest Builder Plugin</name>
-  <version>1.4.26-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
   <description>This Jenkins plugin builds pull requests from Bitbucket.org and will report the test results.</description>
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Bitbucket+pullrequest+builder+plugin</url>    
@@ -42,16 +42,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.maven.wagon</groupId>
-      <artifactId>wagon-http</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1</version>
-    </dependency>
-    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.9</version>
@@ -81,6 +71,16 @@
       <artifactId>easymock</artifactId>
       <version>3.4</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scribe</groupId>
+      <artifactId>scribe</artifactId>
+      <version>1.3.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+      <version>1.22</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -41,8 +41,6 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
     private final String projectPath;
     private final String cron;
     private final String credentialsId;
-    private final String username;
-    private final String password;
     private final String repositoryOwner;
     private final String repositoryName;
     private final String branchesFilter;
@@ -64,8 +62,6 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
             String projectPath,
             String cron,
             String credentialsId,
-            String username,
-            String password,
             String repositoryOwner,
             String repositoryName,
             String branchesFilter,
@@ -82,8 +78,6 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
         this.projectPath = projectPath;
         this.cron = cron;
         this.credentialsId = credentialsId;
-        this.username = username;
-        this.password = password;
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
         this.branchesFilter = branchesFilter;
@@ -107,14 +101,6 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
 
     public String getCredentialsId() {
         return credentialsId;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
     }
 
     public String getRepositoryOwner() {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -47,45 +47,29 @@ public class BitbucketRepository {
     private BitbucketPullRequestsBuilder builder;
     private BitbucketBuildTrigger trigger;
     private ApiClient client;
-    
+
     public BitbucketRepository(String projectPath, BitbucketPullRequestsBuilder builder) {
         this.projectPath = projectPath;
         this.builder = builder;
     }
 
     public void init() {
-        this.init(null, null);
+        this.init(null);
     }
-    
-    public <T extends ApiClient.HttpClientFactory> void init(T httpFactory) {
-        this.init(null, httpFactory);
-    }
-    
+
     public void init(ApiClient client) {
-        this.init(client, null);
-    }
-    
-    public <T extends ApiClient.HttpClientFactory> void init(ApiClient client, T httpFactory) {
         this.trigger = this.builder.getTrigger();
-        
-        if (client == null) {                      
-            String username = trigger.getUsername();
-            String password = trigger.getPassword();            
+
+        if (client == null) {
             StandardUsernamePasswordCredentials credentials = getCredentials(trigger.getCredentialsId());
-            if (credentials != null) {
-                username = credentials.getUsername();
-                password = credentials.getPassword().getPlainText();
-            }            
             this.client = new ApiClient(
-                username,
-                password,
+                credentials,
                 trigger.getRepositoryOwner(),
                 trigger.getRepositoryName(),
                 trigger.getCiKey(),
-                trigger.getCiName(),
-                httpFactory
+                trigger.getCiName()
             );
-            
+
         } else this.client = client;
     }
 
@@ -100,7 +84,7 @@ public class BitbucketRepository {
         }
         return targetPullRequests;
     }
-    
+
     public ApiClient getClient() {
       return this.client;
     }
@@ -160,23 +144,23 @@ public class BitbucketRepository {
     public void postPullRequestApproval(String pullRequestId) {
         this.client.postPullRequestApproval(pullRequestId);
     }
-    
+
     public String getMyBuildTag(String buildKey) {
       return "#" + this.client.buildStatusKey(buildKey);
-    }    
-    
+    }
+
     final static Pattern BUILD_TAGS_RX = Pattern.compile(BUILD_REQUEST_MARKER_TAGS_RX, Pattern.CASE_INSENSITIVE | Pattern.CANON_EQ);
-    final static Pattern SINGLE_BUILD_TAG_RX = Pattern.compile(BUILD_REQUEST_MARKER_TAG_SINGLE_RX, Pattern.CASE_INSENSITIVE | Pattern.CANON_EQ); 
-    final static String CONTENT_PART_TEMPLATE = "```[bid: %s]```";    
-    
+    final static Pattern SINGLE_BUILD_TAG_RX = Pattern.compile(BUILD_REQUEST_MARKER_TAG_SINGLE_RX, Pattern.CASE_INSENSITIVE | Pattern.CANON_EQ);
+    final static String CONTENT_PART_TEMPLATE = "```[bid: %s]```";
+
     private List<String> getAvailableBuildTagsFromTTPComment(String buildTags) {
       logger.log(Level.FINE, "Parse {0}", new Object[]{ buildTags });
-      List<String> availableBuildTags = new LinkedList<String>(); 
+      List<String> availableBuildTags = new LinkedList<String>();
       Matcher subBuildTagMatcher = SINGLE_BUILD_TAG_RX.matcher(buildTags);
       while(subBuildTagMatcher.find()) availableBuildTags.add(subBuildTagMatcher.group(0).trim());
       return availableBuildTags;
     }
-    
+
     public boolean hasMyBuildTagInTTPComment(String content, String buildKey) {
       Matcher tagsMatcher = BUILD_TAGS_RX.matcher(content);
       if (tagsMatcher.find()) {
@@ -184,16 +168,16 @@ public class BitbucketRepository {
         return this.getAvailableBuildTagsFromTTPComment(tagsMatcher.group(1).trim()).contains(this.getMyBuildTag(buildKey));
       }
       else return false;
-    }        
-    
-    private void postBuildTagInTTPComment(String pullRequestId, String content, String buildKey) {     
+    }
+
+    private void postBuildTagInTTPComment(String pullRequestId, String content, String buildKey) {
       logger.log(Level.FINE, "Update build tag for {0} build key", buildKey);
       List<String> builds = this.getAvailableBuildTagsFromTTPComment(content);
-      builds.add(this.getMyBuildTag(buildKey));      
+      builds.add(this.getMyBuildTag(buildKey));
       content += " " + String.format(CONTENT_PART_TEMPLATE, StringUtils.join(builds, " "));
       logger.log(Level.FINE, "Post comment: {0} with original content {1}", new Object[]{ content, this.client.postPullRequestComment(pullRequestId, content).getId() });
     }
-    
+
     private boolean isTTPComment(String content) {
         // special case: in unit tests, trigger is null and can't be mocked
         String commentTrigger = DEFAULT_COMMENT_TRIGGER;
@@ -202,27 +186,27 @@ public class BitbucketRepository {
         }
       return content.toLowerCase().contains(commentTrigger);
     }
-    
+
     private boolean isTTPCommentBuildTags(String content) {
       return content.toLowerCase().contains(BUILD_REQUEST_DONE_MARKER.toLowerCase());
     }
-    
+
     public List<Pullrequest.Comment> filterPullRequestComments(List<Pullrequest.Comment> comments) {
       logger.fine("Filter PullRequest Comments.");
       Collections.sort(comments);
-      Collections.reverse(comments);      
-      List<Pullrequest.Comment> filteredComments = new LinkedList<Pullrequest.Comment>();      
+      Collections.reverse(comments);
+      List<Pullrequest.Comment> filteredComments = new LinkedList<Pullrequest.Comment>();
       for(Pullrequest.Comment comment : comments) {
         String content = comment.getContent();
-        if (content == null || content.isEmpty()) continue;        
-        boolean isTTP = this.isTTPComment(content);        
-        boolean isTTPBuild = this.isTTPCommentBuildTags(content);        
+        if (content == null || content.isEmpty()) continue;
+        boolean isTTP = this.isTTPComment(content);
+        boolean isTTPBuild = this.isTTPCommentBuildTags(content);
         if (isTTP || isTTPBuild)  filteredComments.add(comment);
         if (isTTP) break;
       }
       return filteredComments;
     }
-    
+
     private boolean isBuildTarget(Pullrequest pullRequest) {
         if (pullRequest.getState() != null && pullRequest.getState().equals("OPEN")) {
             if (isSkipBuild(pullRequest.getTitle()) || !isFilteredBuild(pullRequest)) {
@@ -242,10 +226,10 @@ public class BitbucketRepository {
               sourceRepository.getOwnerName(), sourceRepository.getRepositoryName(), sourceCommit, buildKeyPart
             );
             if (commitAlreadyBeenProcessed) logger.log(Level.FINE,
-              "Commit {0}#{1} has already been processed", 
+              "Commit {0}#{1} has already been processed",
               new Object[]{ sourceCommit, buildKeyPart }
             );
-            
+
             final String id = pullRequest.getId();
             List<Pullrequest.Comment> comments = client.getPullRequestComments(owner, repositoryName, id);
 
@@ -255,18 +239,18 @@ public class BitbucketRepository {
                 boolean hasMyBuildTag = false;
                 for (Pullrequest.Comment comment : filteredComments) {
                     String content = comment.getContent();
-                    if (this.isTTPComment(content)) {  
+                    if (this.isTTPComment(content)) {
                         rebuildCommentAvailable = true;
                         logger.log(Level.FINE,
-                          "Rebuild comment available for commit {0} and comment #{1}", 
+                          "Rebuild comment available for commit {0} and comment #{1}",
                           new Object[]{ sourceCommit, comment.getId() }
-                        );                        
+                        );
                     }
                     if (isTTPCommentBuildTags(content))
                         hasMyBuildTag |= this.hasMyBuildTagInTTPComment(content, buildKeyPart);
                 }
                 rebuildCommentAvailable &= !hasMyBuildTag;
-            }            
+            }
             if (rebuildCommentAvailable) this.postBuildTagInTTPComment(id, "TTP build flag", buildKeyPart);
 
             final boolean canBuildTarget = rebuildCommentAvailable || !commitAlreadyBeenProcessed;
@@ -321,17 +305,17 @@ public class BitbucketRepository {
           destinationCommitHash,
           pullRequest.getAuthor().getCombinedUsername()
         );
-        
+
         //@FIXME: Way to iterate over all available SCMSources
         List<SCMSource> sources = new LinkedList<SCMSource>();
         for(SCMSourceOwner owner : SCMSourceOwners.all())
           for(SCMSource src : owner.getSCMSources())
-            sources.add(src);                
-        
-        BitbucketBuildFilter filter = !this.trigger.getBranchesFilterBySCMIncludes() ? 
+            sources.add(src);
+
+        BitbucketBuildFilter filter = !this.trigger.getBranchesFilterBySCMIncludes() ?
           BitbucketBuildFilter.instanceByString(this.trigger.getBranchesFilter()) :
           BitbucketBuildFilter.instanceBySCM(sources, this.trigger.getBranchesFilter());
-        
+
         return filter.approved(cause);
     }
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketApi.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketApi.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Flagbit GmbH & Co. KG.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket;
+
+import org.scribe.builder.api.DefaultApi20;
+import org.scribe.extractors.AccessTokenExtractor;
+import org.scribe.extractors.JsonTokenExtractor;
+import org.scribe.model.OAuthConfig;
+import org.scribe.model.Verb;
+import org.scribe.oauth.OAuthService;
+
+public class BitbucketApi extends DefaultApi20 {
+
+    public static final String OAUTH_ENDPOINT = "https://bitbucket.org/site/oauth2/";
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return OAUTH_ENDPOINT + "access_token";
+    }
+
+    @Override
+    public String getAuthorizationUrl(OAuthConfig config) {
+        return OAUTH_ENDPOINT + "authorize";
+    }
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.POST;
+    }
+
+    @Override
+    public AccessTokenExtractor getAccessTokenExtractor() {
+        return new JsonTokenExtractor();
+    }
+
+    @Override
+    public OAuthService createService(OAuthConfig config) {
+        return new BitbucketApiService(this, config);
+    }
+}

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketApiService.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/BitbucketApiService.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Flagbit GmbH & Co. KG.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket;
+
+import org.eclipse.jgit.util.Base64;
+import org.scribe.builder.api.DefaultApi20;
+import org.scribe.model.*;
+import org.scribe.oauth.OAuth20ServiceImpl;
+
+public class BitbucketApiService extends OAuth20ServiceImpl {
+
+    private static final String GRANT_TYPE_KEY = "grant_type";
+    private static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
+
+    private DefaultApi20 api;
+    private OAuthConfig config;
+
+    public BitbucketApiService(DefaultApi20 api, OAuthConfig config) {
+        super(api, config);
+        this.api = api;
+        this.config = config;
+    }
+
+    @Override
+    public Token getAccessToken(Token requestToken, Verifier verifier) {
+        OAuthRequest request = new OAuthRequest(api.getAccessTokenVerb(), api.getAccessTokenEndpoint());
+        request.addHeader(OAuthConstants.HEADER, this.getHttpBasicAuthHeaderValue());
+        request.addBodyParameter(GRANT_TYPE_KEY, GRANT_TYPE_CLIENT_CREDENTIALS);
+        Response response = request.send();
+
+        return api.getAccessTokenExtractor().extract(response.getBody());
+    }
+
+    @Override
+    public void signRequest(Token accessToken, OAuthRequest request) {
+        request.addHeader(OAuthConstants.HEADER, this.getBearerAuthHeaderValue(accessToken));
+    }
+
+    private String getHttpBasicAuthHeaderValue() {
+        String authStr = config.getApiKey() + ":" + config.getApiSecret();
+
+        return "Basic " + Base64.encodeBytes(authStr.getBytes());
+    }
+
+    private String getBearerAuthHeaderValue(Token token) {
+        return "Bearer " + token.getToken();
+    }
+}

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -6,12 +6,6 @@
   <f:entry title="${%Credentials}" field="credentialsId">
       <c:select/>
   </f:entry>
-  <f:entry title="Bitbucket BasicAuth Username" field="username">
-    <f:textbox />
-  </f:entry>
-  <f:entry title="Bitbucket BasicAuth Password" field="password">
-    <f:password />
-  </f:entry>
   <f:entry title="RepositoryOwner" field="repositoryOwner">
     <f:textbox />
   </f:entry>

--- a/src/test/java/BitbucketBuildRepositoryTest.java
+++ b/src/test/java/BitbucketBuildRepositoryTest.java
@@ -109,44 +109,12 @@ public class BitbucketBuildRepositoryTest {
   @Rule
   public JenkinsRule jRule = new JenkinsRule();  
 
-  @Test  
-  public void repositorySimpleUserPasswordTest() throws Exception {
-    BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
-      "", "@hourly",
-      "JenkinsCID",
-      "foo",
-      "bar",
-      "", "",
-      "", true,
-      "", "", "",
-      true, 
-      true,
-      false, BitbucketRepository.DEFAULT_COMMENT_TRIGGER
-    );
-    
-    BitbucketPullRequestsBuilder builder = EasyMock.createMock(BitbucketPullRequestsBuilder.class); 
-    EasyMock.expect(builder.getTrigger()).andReturn(trigger).anyTimes();
-    EasyMock.replay(builder);
-    
-    ApiClient.HttpClientFactory httpFactory = EasyMock.createNiceMock(ApiClient.HttpClientFactory.class);
-    EasyMock.expect(httpFactory.getInstanceHttpClient()).andReturn(
-      new HttpClientInterceptor(new AssertCredentials(new UsernamePasswordCredentials("foo", "bar")))
-    ).anyTimes();
-    EasyMock.replay(httpFactory);            
-    
-    BitbucketRepository repo = new BitbucketRepository("", builder);
-    repo.init(httpFactory);
-    
-    try { repo.postPullRequestApproval("prId"); } catch(Error e) { assertTrue(e instanceof AssertionError); }
-  }
   
   @Test  
   public void repositoryCtorWithTriggerTest() throws Exception {
     BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
       "", "@hourly",
       "JenkinsCID",
-      "foo",
-      "bar",
       "", "",
       "", true,
       "", "", "",
@@ -164,15 +132,9 @@ public class BitbucketBuildRepositoryTest {
     store.addCredentials(Domain.global(), new UsernamePasswordCredentialsImpl(
       CredentialsScope.GLOBAL, "JenkinsCID", "description", "username", "password"
     ));
-    
-    ApiClient.HttpClientFactory httpFactory = EasyMock.createNiceMock(ApiClient.HttpClientFactory.class);
-    EasyMock.expect(httpFactory.getInstanceHttpClient()).andReturn(
-      new HttpClientInterceptor(new AssertCredentials(new UsernamePasswordCredentials("username", "password")))
-    ).anyTimes();
-    EasyMock.replay(httpFactory);  
-    
+
     BitbucketRepository repo = new BitbucketRepository("", builder);
-    repo.init(httpFactory);        
+    repo.init();
     
     try { repo.postPullRequestApproval("prId"); } catch(Error e) { assertTrue(e instanceof AssertionError); }                
   }
@@ -200,8 +162,6 @@ public class BitbucketBuildRepositoryTest {
     BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
       "", "@hourly",
       "JenkinsCID",
-      "foo",
-      "bar",
       "", "",
       "", true,
       "jenkins", "Jenkins", "",
@@ -247,8 +207,6 @@ public class BitbucketBuildRepositoryTest {
     BitbucketBuildTrigger trigger = new BitbucketBuildTrigger(
       "", "@hourly",
       "JenkinsCID",
-      "foo",
-      "bar",
       "", "",
       "", true,
       "jenkins-too-long-ci-key", "Jenkins", "",


### PR DESCRIPTION
Allows you to create Jenkins credentials for a team rather than a user.