### PR TITLE
improved shortdescription for builds/cause

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerBitbucketCause.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerBitbucketCause.java
@@ -16,7 +16,8 @@ public class ServerBitbucketCause extends BitbucketCause {
 
     @Override
     public String getShortDescription() {
-        return getServerUrl() + "/projects/" + getRepositoryOwner() + "/repos/" + getRepositoryName() + "/pull-requests/" + getPullRequestId();
+        return "#" + getPullRequestId() + " " + getPullRequestTitle()
+                + " (" + getServerUrl() + "/projects/" + getRepositoryOwner() + "/repos/" + getRepositoryName() + "/pull-requests/" + getPullRequestId() + ")";
     }
 
     public String getServerUrl() {


### PR DESCRIPTION
As a developer I want to be able to see the name/description of the pull-request in the build-history - not just the URL to it.