### PR TITLE
Return our response body as a string

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
@@ -174,7 +174,7 @@ public abstract class ApiClient {
                 logger.log(Level.WARNING, "Response status: " + req.getStatusLine()+" URI: "+req.getURI());
                 logger.log(Level.WARNING, IOUtils.toString(req.getResponseBodyAsStream()));
             } else {
-                return IOUtils.toString(req.getResponseBodyAsStream());
+                return req.getResponseBodyAsString();
             }
         } catch (HttpException e) {
             logger.log(Level.WARNING, "Failed to send request.", e);

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
@@ -8,7 +8,6 @@ import org.apache.commons.httpclient.methods.*;
 import org.apache.commons.httpclient.methods.DeleteMethod;
 import org.apache.commons.httpclient.params.HttpClientParams;
 import org.apache.commons.httpclient.util.EncodingUtil;
-import org.apache.commons.io.IOUtils;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.JavaType;
 import org.codehaus.jackson.type.TypeReference;
@@ -172,7 +171,7 @@ public abstract class ApiClient {
                 return null;
             } else if (statusCode != HttpStatus.SC_OK) {
                 logger.log(Level.WARNING, "Response status: " + req.getStatusLine()+" URI: "+req.getURI());
-                logger.log(Level.WARNING, IOUtils.toString(req.getResponseBodyAsStream()));
+                logger.log(Level.WARNING, req.getResponseBodyAsString());
             } else {
                 return req.getResponseBodyAsString();
             }


### PR DESCRIPTION
While also more efficient, I think it *may* solve the socket timeout
problem, where read() hangs in the middle of getResponseBodyAsStream()