### PR TITLE
Add git clone URL to build specification

### DIFF
--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -237,11 +237,16 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
             }
         };
 
-        URIish repoUri;
+        URIish repoUri = null;
         try {
-            repoUri = new URIish(cause.getRepositoryUri());
+            final String repositoryUri = cause.getRepositoryUri();
+            if (repositoryUri != null) {
+                repoUri = new URIish(repositoryUri);
+            } else {
+                logger.fine("No repository URI specified");
+            }
         } catch (URISyntaxException e) {
-            repoUri = null;
+            logger.log(Level.FINE, "Repository URI error: {0}", e.getMessage());
         }
 
         return scheduledJob.scheduleBuild2(

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -237,11 +237,18 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
             }
         };
 
+        URIish repoUri;
+        try {
+            repoUri = new URIish(cause.getRepositoryUri());
+        } catch (URISyntaxException e) {
+            repoUri = null;
+        }
+
         return scheduledJob.scheduleBuild2(
             this.getInstance().getQuietPeriod(),
             new CauseAction(cause),
             new ParametersAction(new ArrayList<ParameterValue>(values.values())),
-            new RevisionParameterAction(cause.getSourceCommitHash())
+            new RevisionParameterAction(cause.getSourceCommitHash(), repoUri)
         );
     }
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketCause.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketCause.java
@@ -7,6 +7,7 @@ public abstract class BitbucketCause extends Cause {
     private final String targetBranch;
     private final String repositoryOwner;
     private final String repositoryName;
+    private final String repositoryUri;
     private final String pullRequestId;
     private final String destinationRepositoryOwner;
     private final String destinationRepositoryName;
@@ -15,11 +16,15 @@ public abstract class BitbucketCause extends Cause {
     private final String destinationCommitHash;
     private final String pullRequestAuthor;
 
-    protected BitbucketCause(String sourceBranch, String targetBranch, String repositoryOwner, String repositoryName, String pullRequestId, String destinationRepositoryOwner, String destinationRepositoryName, String pullRequestTitle, String sourceCommitHash, String destinationCommitHash, String pullRequestAuthor) {
+    protected BitbucketCause(String sourceBranch, String targetBranch, String repositoryOwner, String repositoryName,
+                             String repositoryUri, String pullRequestId, String destinationRepositoryOwner,
+                             String destinationRepositoryName, String pullRequestTitle, String sourceCommitHash,
+                             String destinationCommitHash, String pullRequestAuthor) {
         this.sourceBranch = sourceBranch;
         this.targetBranch = targetBranch;
         this.repositoryOwner = repositoryOwner;
         this.repositoryName = repositoryName;
+        this.repositoryUri = repositoryUri;
         this.pullRequestId = pullRequestId;
         this.destinationRepositoryOwner = destinationRepositoryOwner;
         this.destinationRepositoryName = destinationRepositoryName;
@@ -43,6 +48,10 @@ public abstract class BitbucketCause extends Cause {
 
     public String getRepositoryName() {
         return repositoryName;
+    }
+
+    public String getRepositoryUri() {
+        return repositoryUri;
     }
 
     public String getPullRequestId() {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -154,11 +154,17 @@ public class BitbucketRepository {
             destinationCommitHash = pullRequest.getDestination().getCommit().getHash();
         }
 
-        final List<AbstractPullrequest.RepositoryLink> cloneLinks = pullRequest.getSource().getRepository().getLinks().getClone();
-        String sshRepoUri = null;
-        for (AbstractPullrequest.RepositoryLink cloneLink : cloneLinks) {
-            if ( "ssh".equals(cloneLink.getName()) ) {
-                sshRepoUri = cloneLink.getHref();
+        final AbstractPullrequest.RepositoryLinks links = pullRequest.getSource().getRepository().getLinks();
+        String repoUri = null;
+
+        if(links != null) {
+            final List<AbstractPullrequest.RepositoryLink> cloneLinks = links.getClone();
+            if (cloneLinks != null) {
+                for (AbstractPullrequest.RepositoryLink cloneLink : cloneLinks) {
+                    if ( repoUri == null || "ssh".equals(cloneLink.getName()) ) { // prefer ssh URIs
+                        repoUri = cloneLink.getHref();
+                    }
+                }
             }
         }
 
@@ -169,7 +175,7 @@ public class BitbucketRepository {
                 pullRequest.getDestination().getBranch().getName(),
                 pullRequest.getSource().getRepository().getOwnerName(),
                 pullRequest.getSource().getRepository().getRepositoryName(),
-                sshRepoUri,
+                repoUri,
                 pullRequest.getId(),
                 pullRequest.getDestination().getRepository().getOwnerName(),
                 pullRequest.getDestination().getRepository().getRepositoryName(),
@@ -185,7 +191,7 @@ public class BitbucketRepository {
                 pullRequest.getDestination().getBranch().getName(),
                 pullRequest.getSource().getRepository().getOwnerName(),
                 pullRequest.getSource().getRepository().getRepositoryName(),
-                sshRepoUri,
+                repoUri,
                 pullRequest.getId(),
                 pullRequest.getDestination().getRepository().getOwnerName(),
                 pullRequest.getDestination().getRepository().getRepositoryName(),

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -154,6 +154,14 @@ public class BitbucketRepository {
             destinationCommitHash = pullRequest.getDestination().getCommit().getHash();
         }
 
+        final List<AbstractPullrequest.RepositoryLink> cloneLinks = pullRequest.getSource().getRepository().getLinks().getClone();
+        String sshRepoUri = null;
+        for (AbstractPullrequest.RepositoryLink cloneLink : cloneLinks) {
+            if ( "ssh".equals(cloneLink.getName()) ) {
+                sshRepoUri = cloneLink.getHref();
+            }
+        }
+
         final BitbucketCause cause;
         if (this.trigger.isCloud()) {
             cause = new CloudBitbucketCause(
@@ -161,12 +169,13 @@ public class BitbucketRepository {
                 pullRequest.getDestination().getBranch().getName(),
                 pullRequest.getSource().getRepository().getOwnerName(),
                 pullRequest.getSource().getRepository().getRepositoryName(),
+                sshRepoUri,
                 pullRequest.getId(),
                 pullRequest.getDestination().getRepository().getOwnerName(),
                 pullRequest.getDestination().getRepository().getRepositoryName(),
                 pullRequest.getTitle(),
                 pullRequest.getSource().getCommit().getHash(),
-                    destinationCommitHash,
+                destinationCommitHash,
                 pullRequest.getAuthor().getCombinedUsername()
             );
         } else {
@@ -176,6 +185,7 @@ public class BitbucketRepository {
                 pullRequest.getDestination().getBranch().getName(),
                 pullRequest.getSource().getRepository().getOwnerName(),
                 pullRequest.getSource().getRepository().getRepositoryName(),
+                sshRepoUri,
                 pullRequest.getId(),
                 pullRequest.getDestination().getRepository().getOwnerName(),
                 pullRequest.getDestination().getRepository().getRepositoryName(),

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/AbstractPullrequest.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/AbstractPullrequest.java
@@ -3,6 +3,7 @@ package bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractPullrequest {
@@ -23,6 +24,39 @@ public abstract class AbstractPullrequest {
         String getOwnerName();
 
         String getRepositoryName();
+
+        RepositoryLinks getLinks();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RepositoryLinks {
+        private List<RepositoryLink> clone = new ArrayList<>();
+
+        public void setClone(List<RepositoryLink> clone) {
+            this.clone = clone;
+        }
+        public List<RepositoryLink> getClone() {
+            return clone;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class RepositoryLink {
+        private String name;
+        private String href;
+
+        public void setName(String name) {
+            this.name = name;
+        }
+        public void setHref(String href) {
+            this.href = href;
+        }
+        public String getName() {
+            return name;
+        }
+        public String getHref() {
+            return href;
+        }
     }
 
     public interface Branch {

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/ApiClient.java
@@ -23,7 +23,6 @@ import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 import hudson.ProxyConfiguration;
-import jenkins.model.Jenkins;
 
 /**
  * Created by nishio

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudApiClient.java
@@ -4,16 +4,15 @@ import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.Abstrac
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.ApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BuildState;
 import org.apache.commons.httpclient.NameValuePair;
-import org.codehaus.jackson.map.type.MapType;
 import org.codehaus.jackson.map.type.TypeFactory;
 import org.codehaus.jackson.type.JavaType;
 import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -29,49 +28,19 @@ public class CloudApiClient extends ApiClient {
 
     @Override
     public List<CloudPullrequest> getPullRequests() {
-        final List<CloudPullrequest> pullrequests = getAllValues(v2("/pullrequests/"), 50, CloudPullrequest.class);
-        return addRepositoryUris(pullrequests);
-    }
-
-    private List<CloudPullrequest> addRepositoryUris(List<CloudPullrequest> pullrequests) {
-        final AbstractPullrequest.RepositoryLinks repositoryLinks = getRepositoryLinks();
-        if (repositoryLinks != null) {
-            for (CloudPullrequest pullrequest : pullrequests) {
-                final CloudPullrequest.Repository sourceRepository = pullrequest.getSource().getRepository();
-                final AbstractPullrequest.RepositoryLinks links = sourceRepository.getLinks();
-                if(links.getClone().isEmpty()) {
-                    sourceRepository.setLinks(repositoryLinks);
-                }
-            }
-        }
-        return pullrequests;
+        return getAllValues(
+                v2("/pullrequests/"),
+                50,
+                "+values.source.repository.links.clone.*",
+                CloudPullrequest.class
+        );
     }
 
     @Override
     public List<AbstractPullrequest.Comment> getPullRequestComments(String commentOwnerName, String commentRepositoryName, String pullRequestId) {
 
-        final List<CloudPullrequest.Comment> comments = getAllValues(v2("/pullrequests/" + pullRequestId + "/comments"), 100, CloudPullrequest.Comment.class);
+        final List<CloudPullrequest.Comment> comments = getAllValues(v2("/pullrequests/" + pullRequestId + "/comments"), 100, null, CloudPullrequest.Comment.class);
         return cloudToAbstractComments(comments);
-    }
-
-    public AbstractPullrequest.RepositoryLinks getRepositoryLinks() {
-        final String url = v2("/?fields=links");
-        final String body = get(url);
-        logger.log(Level.FINE, "****Received("+url+")****:\n" + body + "\n");
-        AbstractPullrequest.RepositoryLinks ret = null;
-        try {
-            final TypeFactory typeFactory = TypeFactory.defaultInstance();
-            final MapType responseType = typeFactory.constructMapType(
-                    HashMap.class,
-                    String.class,
-                    AbstractPullrequest.RepositoryLinks.class
-            );
-            final Map<String, AbstractPullrequest.RepositoryLinks> map = parse(body, responseType);
-            ret = map.get("links");
-        } catch (IOException e) {
-            logger.log(Level.WARNING, "invalid response.", e);
-        }
-        return ret;
     }
 
     private List<AbstractPullrequest.Comment> cloudToAbstractComments(List<CloudPullrequest.Comment> comments) {
@@ -162,10 +131,13 @@ public class CloudApiClient extends ApiClient {
         return V2_API_BASE_URL + owner + "/" + repositoryName + path;
     }
 
-    private <T> List<T> getAllValues(String rootUrl, int pageLen, Class<T> cls) {
+    private <T> List<T> getAllValues(String rootUrl, int pageLen, String additionalFieldsSpec, Class<T> cls) {
         List<T> values = new ArrayList<T>();
         try {
             String url = rootUrl + "?pagelen=" + pageLen;
+            if (additionalFieldsSpec != null) {
+                url += "&fields=" + URLEncoder.encode(additionalFieldsSpec, StandardCharsets.UTF_8.toString());
+            }
             do {
                 final JavaType type = TypeFactory.defaultInstance().constructParametricType(AbstractPullrequest.Response.class, cls);
                 final String body = get(url);

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudBitbucketCause.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudBitbucketCause.java
@@ -13,6 +13,7 @@ public class CloudBitbucketCause extends BitbucketCause {
                                String targetBranch,
                                String repositoryOwner,
                                String repositoryName,
+                               String repositoryUri,
                                String pullRequestId,
                                String destinationRepositoryOwner,
                                String destinationRepositoryName,
@@ -20,7 +21,9 @@ public class CloudBitbucketCause extends BitbucketCause {
                                String sourceCommitHash,
                                String destinationCommitHash,
                                String pullRequestAuthor) {
-        super(sourceBranch, targetBranch, repositoryOwner, repositoryName, pullRequestId, destinationRepositoryOwner, destinationRepositoryName, pullRequestTitle, sourceCommitHash, destinationCommitHash, pullRequestAuthor);
+        super(sourceBranch, targetBranch, repositoryOwner, repositoryName, repositoryUri, pullRequestId,
+                destinationRepositoryOwner, destinationRepositoryName, pullRequestTitle, sourceCommitHash,
+                destinationCommitHash, pullRequestAuthor);
     }
 
     @Override

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudPullrequest.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/cloud/CloudPullrequest.java
@@ -61,6 +61,7 @@ public class CloudPullrequest extends AbstractPullrequest {
         private String name;
         private String ownerName;
         private String repositoryName;
+        private RepositoryLinks links;
 
         @JsonProperty("full_name")
         public String getFullName() {
@@ -81,11 +82,17 @@ public class CloudPullrequest extends AbstractPullrequest {
         public void setName(String name) {
             this.name = name;
         }
-        public String getOwnerName() {
+        public void setLinks(RepositoryLinks links) {
+            this.links = links;
+        }
+        @Override public String getOwnerName() {
             return ownerName;
         }
-        public String getRepositoryName() {
+        @Override public String getRepositoryName() {
             return repositoryName;
+        }
+        @Override public RepositoryLinks getLinks() {
+            return links;
         }
     }
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerApiClient.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerApiClient.java
@@ -6,8 +6,10 @@ import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.BuildSt
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.cloud.CloudApiClient;
 import bitbucketpullrequestbuilder.bitbucketpullrequestbuilder.bitbucket.cloud.CloudPullrequest;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.httpclient.NameValuePair;
 import org.codehaus.jackson.map.type.TypeFactory;
 import org.codehaus.jackson.type.JavaType;
+import org.codehaus.jackson.type.TypeReference;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,38 +34,7 @@ public class ServerApiClient extends ApiClient {
 
     @Override
     public List<ServerPullrequest> getPullRequests() {
-        final List<ServerPullrequest> pullrequests = getAllValues(restV1(PULL_REQUESTS_URL), ServerPullrequest.class);
-        return addRepositoryUrls(pullrequests);
-    }
-
-    private List<ServerPullrequest> addRepositoryUrls(List<ServerPullrequest> pullrequests) {
-        final AbstractPullrequest.RepositoryLinks repositoryLinks = getRepositoryLinks();
-        if (repositoryLinks != null) {
-            for (ServerPullrequest pullrequest : pullrequests) {
-                final ServerPullrequest.Repository sourceRepository = pullrequest.getSource().getRepository();
-                final AbstractPullrequest.RepositoryLinks links = sourceRepository.getLinks();
-                if(links.getClone().isEmpty()) {
-                    sourceRepository.setLinks(repositoryLinks);
-                }
-            }
-        }
-        return pullrequests;
-    }
-
-    public AbstractPullrequest.RepositoryLinks getRepositoryLinks() {
-        final String body = get(restV1(""));
-        AbstractPullrequest.RepositoryLinks ret = null;
-        try {
-            final TypeFactory typeFactory = TypeFactory.defaultInstance();
-            final ServerPullrequest.Repository repository = parse(
-                    body,
-                    typeFactory.constructType(ServerPullrequest.Repository.class)
-            );
-            ret = repository.getLinks();
-        } catch (IOException e) {
-            logger.log(Level.WARNING, "invalid response.", e);
-        }
-        return ret;
+        return getAllValues(restV1(PULL_REQUESTS_URL), ServerPullrequest.class);
     }
 
     @Override

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerBitbucketCause.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerBitbucketCause.java
@@ -7,10 +7,12 @@ public class ServerBitbucketCause extends BitbucketCause {
     private final String serverUrl;
 
     public ServerBitbucketCause(String serverUrl, String sourceBranch, String targetBranch, String repositoryOwner,
-                                String repositoryName, String pullRequestId, String destinationRepositoryOwner,
+                                String repositoryName, String repositoryUri, String pullRequestId, String destinationRepositoryOwner,
                                 String destinationRepositoryName, String pullRequestTitle, String sourceCommitHash,
                                 String destinationCommitHash, String pullRequestAuthor) {
-        super(sourceBranch, targetBranch, repositoryOwner, repositoryName, pullRequestId, destinationRepositoryOwner, destinationRepositoryName, pullRequestTitle, sourceCommitHash, destinationCommitHash, pullRequestAuthor);
+        super(sourceBranch, targetBranch, repositoryOwner, repositoryName, repositoryUri, pullRequestId,
+                destinationRepositoryOwner, destinationRepositoryName, pullRequestTitle, sourceCommitHash,
+                destinationCommitHash, pullRequestAuthor);
         this.serverUrl = serverUrl;
     }
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerPullrequest.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/bitbucket/server/ServerPullrequest.java
@@ -98,6 +98,7 @@ public class ServerPullrequest extends AbstractPullrequest {
         private String name;
         private String slug;
         private String ownerName;
+        private RepositoryLinks links;
 
         @JsonProperty("project")
         private void unpackProject(Map<String, Object> project) {
@@ -110,6 +111,10 @@ public class ServerPullrequest extends AbstractPullrequest {
 
         public void setSlug(String slug) {
             this.slug = slug;
+        }
+
+        public void setLinks(RepositoryLinks links) {
+            this.links = links;
         }
 
         @Override
@@ -125,6 +130,11 @@ public class ServerPullrequest extends AbstractPullrequest {
         @Override
         public String getRepositoryName() {
             return slug;
+        }
+
+        @Override
+        public RepositoryLinks getLinks() {
+            return links;
         }
     }
 


### PR DESCRIPTION
This adds git URL to the scheduled build specification. It actually solves a problem of mine where a pre-build merge (i.e. merge a feature branch from the BitBucket pull request into master before running the build on Jenkins) would fail because this information was not available. The investigation was done a long time ago, so the details are hazy. 
Anyway, I've changed the API call only for the cloud version. Works for me, but help with testing for BitBucket Server instance would be appreciated. I think according to the BitBucket Server API docs there should be no change needed. I think the worst that can happen is a null field for the BitBucket Server.