### PR TITLE
Add option to build Pull Requests in reverse order

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ pipeline {
         checkDestinationCommit:false,
         approveIfSuccess:false,
         cancelOutdatedJobs:true,
+        buildChronologically: true,
         commentTrigger:'')
     }
 }

--- a/README.md
+++ b/README.md
@@ -45,22 +45,22 @@ pipeline {
     agent any
     triggers{
         bitbucketpr(projectPath:'<BIT_BUCKET_PATH>',
-        cron:'H/15 * * * *',
-        credentialsId:'',
-        username:'',
-        password:'',
-        repositoryOwner:'',
-        repositoryName:'',
-        branchesFilter:'',
-        branchesFilterBySCMIncludes:false,
-        ciKey:'',
-        ciName:'',
-        ciSkipPhrases:'',
-        checkDestinationCommit:false,
-        approveIfSuccess:false,
-        cancelOutdatedJobs:true,
-        buildChronologically: true,
-        commentTrigger:'')
+            cron: 'H/15 * * * *',
+            credentialsId: '',
+            username: '',
+            password: '',
+            repositoryOwner: '',
+            repositoryName: '',
+            branchesFilter: '',
+            branchesFilterBySCMIncludes: false,
+            ciKey: '',
+            ciName: '',
+            ciSkipPhrases: '',
+            checkDestinationCommit: false,
+            approveIfSuccess: false,
+            cancelOutdatedJobs: true,
+            buildChronologically: true,
+            commentTrigger: '')
     }
 }
 ```

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger.java
@@ -75,6 +75,7 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
     private final boolean checkDestinationCommit;
     private final boolean approveIfSuccess;
     private final boolean cancelOutdatedJobs;
+    private final boolean buildChronologically;
     private final String commentTrigger;
 
     transient private BitbucketPullRequestsBuilder bitbucketPullRequestsBuilder;
@@ -99,6 +100,7 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
             boolean checkDestinationCommit,
             boolean approveIfSuccess,
             boolean cancelOutdatedJobs,
+            boolean buildChronologically,
             String commentTrigger
             ) throws ANTLRException {
         super(cron);
@@ -118,6 +120,7 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
         this.checkDestinationCommit = checkDestinationCommit;
         this.approveIfSuccess = approveIfSuccess;
         this.cancelOutdatedJobs = cancelOutdatedJobs;
+        this.buildChronologically = buildChronologically;
         this.commentTrigger = commentTrigger;
     }
 
@@ -183,6 +186,10 @@ public class BitbucketBuildTrigger extends Trigger<Job<?, ?>> {
 
     public boolean getCancelOutdatedJobs() {
         return cancelOutdatedJobs;
+    }
+
+    public boolean getBuildChronologically() {
+        return buildChronologically;
     }
 
     /**

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -112,8 +112,6 @@ public class BitbucketRepository {
     }
 
     public <T extends AbstractPullrequest> List<T> getTargetPullRequests() {
-        this.trigger = this.builder.getTrigger();
-        
         logger.fine("Fetch PullRequests.");
         List<T> pullRequests = client.getPullRequests();
         List<T> targetPullRequests = new ArrayList<>();

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -121,6 +121,10 @@ public class BitbucketRepository {
                 targetPullRequests.add(pullRequest);
             }
         }
+
+        if (trigger.getBuildChronologically()){
+            Collections.reverse(targetPullRequests);
+        }
         return targetPullRequests;
     }
 

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -54,6 +54,7 @@ public class BitbucketRepository {
 
     public BitbucketRepository(String projectPath, BitbucketPullRequestsBuilder builder) {
         this.builder = builder;
+        this.trigger = this.builder.getTrigger();
     }
 
     public void init() {
@@ -69,8 +70,6 @@ public class BitbucketRepository {
     }
 
     public <T extends ApiClient.HttpClientFactory> void init(ApiClient client, T httpFactory) {
-        this.trigger = this.builder.getTrigger();
-
         if (client == null) {
             String username = trigger.getUsername();
             String password = trigger.getPassword();

--- a/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
+++ b/src/main/java/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketRepository.java
@@ -112,6 +112,8 @@ public class BitbucketRepository {
     }
 
     public <T extends AbstractPullrequest> List<T> getTargetPullRequests() {
+        this.trigger = this.builder.getTrigger();
+        
         logger.fine("Fetch PullRequests.");
         List<T> pullRequests = client.getPullRequests();
         List<T> targetPullRequests = new ArrayList<>();

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/config.jelly
@@ -45,6 +45,9 @@
   <f:entry title="Cancel outdated jobs?" field="cancelOutdatedJobs">
     <f:checkbox default="false"/>
   </f:entry>
+  <f:entry title="Build chronologically?" field="buildChronologically">
+    <f:checkbox default="false"/>
+  </f:entry>
   <f:entry title="Comment phrase to trigger build" field="commentTrigger">
     <f:textbox default="test this please"/>
   </f:entry>

--- a/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/help-buildChronologically.html
+++ b/src/main/resources/bitbucketpullrequestbuilder/bitbucketpullrequestbuilder/BitbucketBuildTrigger/help-buildChronologically.html
@@ -1,0 +1,1 @@
+Build Pull Requests in reverse order - older request will be build first

--- a/src/test/java/BitbucketBuildRepositoryTest.java
+++ b/src/test/java/BitbucketBuildRepositoryTest.java
@@ -123,6 +123,7 @@ public class BitbucketBuildRepositoryTest {
       "", "", "",
       true, 
       true,
+      true,
       false, BitbucketRepository.DEFAULT_COMMENT_TRIGGER
     );
     
@@ -153,6 +154,7 @@ public class BitbucketBuildRepositoryTest {
       "", true,
       "", "", "",
       true, 
+      true,
       true,
       false, BitbucketRepository.DEFAULT_COMMENT_TRIGGER
     );          
@@ -209,6 +211,7 @@ public class BitbucketBuildRepositoryTest {
       "jenkins", "Jenkins", "",
       true, 
       true,
+      true,
       false, BitbucketRepository.DEFAULT_COMMENT_TRIGGER
     );
     
@@ -256,6 +259,7 @@ public class BitbucketBuildRepositoryTest {
       "jenkins-too-long-ci-key", "Jenkins", "",
       true, 
       true,
+      true,
       false, BitbucketRepository.DEFAULT_COMMENT_TRIGGER
     );
     
@@ -287,6 +291,7 @@ public class BitbucketBuildRepositoryTest {
     EasyMock.expect(trigger.getBranchesFilter()).andReturn("");
     EasyMock.expect(trigger.isCloud()).andReturn(true);
     EasyMock.expect(trigger.getBitbucketServer()).andReturn(null);
+    EasyMock.expect(trigger.getBuildChronologically().andReturn(true));
     EasyMock.replay(trigger);
 
     // setup mock BitbucketPullRequestsBuilder

--- a/src/test/java/BitbucketBuildRepositoryTest.java
+++ b/src/test/java/BitbucketBuildRepositoryTest.java
@@ -291,7 +291,6 @@ public class BitbucketBuildRepositoryTest {
     EasyMock.expect(trigger.getBranchesFilter()).andReturn("");
     EasyMock.expect(trigger.isCloud()).andReturn(true);
     EasyMock.expect(trigger.getBitbucketServer()).andReturn(null);
-    EasyMock.expect(trigger.getBuildChronologically().andReturn(true));
     EasyMock.replay(trigger);
 
     // setup mock BitbucketPullRequestsBuilder


### PR DESCRIPTION
Default order for BitBucket Pull Requests is 'newer first'.
This option allow to reverse this order.

Chronological order more fair if you have a lot of pull requests that can be merged to target branch only after Jenkins approve.

If you do automatic merge pull requests after successful build, this option will help to avoid merge conflicts.